### PR TITLE
Create es.yaml

### DIFF
--- a/grott-current/Dockerfile
+++ b/grott-current/Dockerfile
@@ -22,9 +22,9 @@ RUN pip3 install --no-cache --upgrade pip setuptools
 # Copy data for add-on
 COPY script.sh /app/script.sh
 WORKDIR /app
-RUN curl -Lk 'https://github.com/johanmeijer/grott/archive/refs/heads/2.7-(Beta).zip' --output files.zip && unzip -o files.zip && rm files.zip && mv grott-*/*.py ./
+RUN curl -Lk 'https://github.com/perico85/grott/archive/refs/heads/patch-1.zip' --output files.zip && unzip -o files.zip && rm files.zip && mv grott-*/*.py ./
 # Move the addon
-RUN curl -L 'https://raw.githubusercontent.com/egguy/grott/feature/ha-extension/examples/Home%20Assistent/grott_ha.py' -o grott_ha.py
+RUN curl -L 'https://raw.githubusercontent.com/johanmeijer/grott/Beta-(2.8.x)/examples/Home%20Assistent/grott_ha.py' -o grott_ha.py
 
 #Install required python packages 
 RUN pip install paho-mqtt requests influxdb influxdb

--- a/grott-current/translations/es.yaml
+++ b/grott-current/translations/es.yaml
@@ -1,0 +1,20 @@
+---
+configuración:
+  gverbose:
+    nombre: Modo Verbose.
+    descripción: Activa el modo verbose. Útil para depuración.
+  gminrecl:
+    nombre: Longitud mínima de registro.
+    descripción: La longitud mínima del paquete a tratar.
+  gnomqtt
+    nombre: Desactivar grott MQTT.
+    descripción: Evita que grott envíe mensajes MQTT, el complemento tiene su propia mensajería MQTT, por lo que esta configuración no es necesaria.
+  ginvtype:
+    name: Tipo de inversor.
+    descripción: "Para cambiar el diseño utilizado para la decodificación (ej: sph, spf o tl3). Mantenlo por defecto si usas inverter map".
+  ginvtypemap:
+    nombre: mapeo inverso.
+    descripción: 'Un mapeo inverso de la forma {"NUMERO_DE_SERIE": "tipo"} p. ej.: para un inversor SPH6000 con número serie "NWO00415E3", quedaría de la siguiente manera {"NWO00415E3": "sph"}'
+
+red:
+  5279/TCP: Este es el puerto utilizado por grott para recibir información del registrador de datos.

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
-name: Grott for Home Assistant
-url: 'https://github.com/egguy/grott-home-assistant-add-on'
-maintainer: egguy
+name: Grott for Home Assistant Mod PERICO85
+url: 'https://github.com/perico85/grott/tree/patch-1'
+maintainer: perico85 fork form egguy


### PR DESCRIPTION
# TRADUCCION AL ESPAÑOL DE LA CONFIGURACION / SPANISH TRANSLATION OF CONFIGURATION.
---
configuración:
  gverbose:
    nombre: Modo Verbose.
    descripción: Activa el modo verbose. Útil para depuración.
  gminrecl:
    nombre: Longitud mínima de registro.
    descripción: La longitud mínima del paquete a tratar.
  gnomqtt
    nombre: Desactivar grott MQTT.
    descripción: Evita que grott envíe mensajes MQTT, el complemento tiene su propia mensajería MQTT, por lo que esta configuración no es necesaria.
  ginvtype:
    name: Tipo de inversor.
    descripción: "Para cambiar el diseño utilizado para la decodificación (ej: sph, spf o tl3). Mantenlo por defecto si usas inverter map".
  ginvtypemap:
    nombre: mapeo inverso.
    descripción: 'Un mapeo inverso de la forma {"NUMERO_DE_SERIE": "tipo"} p. ej.: para un inversor SPH6000 con número serie "NWO00415E3", quedaría de la siguiente manera {"NWO00415E3": "sph"}'

red:
  5279/TCP: Este es el puerto utilizado por grott para recibir información del registrador de datos.